### PR TITLE
feat: CacheDir is configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	CacheDir = "/var/lib/yara-rule-server"
-	RulePath = "/var/lib/yara-rule-server/compiled"
+	CompiledRuleFileName = "compiled"
+	TempDirName          = "tmp"
 )
 
 type Config struct {
@@ -33,6 +33,7 @@ type Config struct {
 	RuleUpdateSchedule        string       `mapstructure:"rule_update_schedule"`
 	ServerAddress             string       `mapstructure:"server_address"`
 	HealthCheckAddressAddress string       `mapstructure:"health_check_address"`
+	CacheDir                  string       `mapstructure:"cache_dir"`
 }
 
 type RuleSource struct {
@@ -71,4 +72,5 @@ func setDefaults() {
 	viper.SetDefault("rule_update_schedule", "0 0 * * *")
 	viper.SetDefault("server_address", ":8080")
 	viper.SetDefault("health_check_address", ":8082")
+	viper.SetDefault("cache_dir", "/var/lib/yara-rule-server")
 }

--- a/pkg/fileserver/fileserver.go
+++ b/pkg/fileserver/fileserver.go
@@ -18,6 +18,7 @@ package fileserver
 import (
 	"errors"
 	"net/http"
+	"path"
 
 	"github.com/sirupsen/logrus"
 
@@ -25,9 +26,10 @@ import (
 )
 
 func Start(cfg *config.Config, logger *logrus.Entry) *http.Server {
-	logger.Infof("Starting file server. Rule file: %s", config.RulePath)
+	compiledRulePath := path.Join(cfg.CacheDir, config.CompiledRuleFileName)
+	logger.Infof("Starting file server. Rule file: %s", compiledRulePath)
 	sFile := func(w http.ResponseWriter, req *http.Request) {
-		http.ServeFile(w, req, config.RulePath)
+		http.ServeFile(w, req, compiledRulePath)
 	}
 
 	http.HandleFunc("/", sFile)

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -32,13 +32,13 @@ import (
 func DownloadAndCompile(cfg *config.Config, logger *logrus.Entry) error {
 	// First try to download new copies of all the sources
 	yarFilesToIndex := make([]string, 0)
-	tempDir := path.Join(config.CacheDir, "tmp")
+	tempDir := path.Join(cfg.CacheDir, config.TempDirName)
 	if err := os.MkdirAll(tempDir, 0755); err != nil {
 		return fmt.Errorf("failed to create yara rule server temp directory. tempDir=%s: %v", tempDir, err)
 	}
 	for _, source := range cfg.RuleSources {
 		// Create directory for this source if it doesn't exist
-		sourceDir := path.Join(config.CacheDir, "sources", source.Name)
+		sourceDir := path.Join(cfg.CacheDir, "sources", source.Name)
 		if err := os.MkdirAll(sourceDir, 0755); err != nil {
 			logger.WithError(err).Errorf("Failed to create directory %s. Using the last successful download if available", sourceDir)
 			continue
@@ -67,7 +67,7 @@ func DownloadAndCompile(cfg *config.Config, logger *logrus.Entry) error {
 		yarFilesToIndex = append(yarFilesToIndex, yarFiles...)
 	}
 
-	if err := generateIndexAndCompile(cfg.YaracPath, yarFilesToIndex, tempDir); err != nil {
+	if err := generateIndexAndCompile(cfg, yarFilesToIndex, tempDir); err != nil {
 		return fmt.Errorf("failed to create compiled rules: %v", err)
 	}
 


### PR DESCRIPTION
## Description

This PR makes it possible to define `CacheDir`.
fixes: #16 

The default value of the `CaheDir` is the previous one, so if it is not defined it will work as before.

Example config:
```
cache_dir: "/var/lib/mycache"
```

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/yara-rule-server/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
